### PR TITLE
fix(codeql): add packages: read and pin gha-security to v2.13.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,9 +15,10 @@ on:
 jobs:
   code-scan:
     name: CodeQL Scan
-    uses: entur/gha-security/.github/workflows/code-scan.yml@v2
+    uses: entur/gha-security/.github/workflows/code-scan.yml@aeebe7ddac5952b3ef9f14380e2d5884b42a6c2e  # v2.13.0
     # no secrets necessary
     permissions: # some of these only apply when running on the main branch
+      packages: read
       actions: read
       contents: write
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,13 +15,12 @@ on:
 jobs:
   code-scan:
     name: CodeQL Scan
-    uses: entur/gha-security/.github/workflows/code-scan.yml@aeebe7ddac5952b3ef9f14380e2d5884b42a6c2e  # v2.13.0
+    uses: entur/gha-security/.github/workflows/code-scan.yml@v2
     # no secrets necessary
     permissions:
-      # CodeQL - required to fetch Maven package from Github Registry
       packages: read
-      # CodeQL - required for all workflows
       security-events: write
-      # CodeQL - only required for workflows in private repositories
       actions: read
-      contents: read
+      contents: write
+      issues: write
+      pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,17 +17,11 @@ jobs:
     name: CodeQL Scan
     uses: entur/gha-security/.github/workflows/code-scan.yml@aeebe7ddac5952b3ef9f14380e2d5884b42a6c2e  # v2.13.0
     # no secrets necessary
-    permissions: # some of these only apply when running on the main branch
+    permissions:
+      # CodeQL - required to fetch Maven package from Github Registry
       packages: read
-      actions: read
-      contents: write
-      pull-requests: write
+      # CodeQL - required for all workflows
       security-events: write
-      issues: write
-    with:
-      use_setup_java: true
-      java_version: "25"
-      java_distribution: "liberica"
-      java_server_id_artifactory: entur-partner
-      use_maven_cache: true
-      job_runner: grp-ubuntu-24.04-16core-x64
+      # CodeQL - only required for workflows in private repositories
+      actions: read
+      contents: read


### PR DESCRIPTION
## Summary
- Adds `packages: read` permission required by updated CodeQL action from Team Sikkerhet
- Pins `entur/gha-security` to `aeebe7ddac5952b3ef9f14380e2d5884b42a6c2e` (v2.13.0)

## Files changed
- `.github/workflows/codeql.yml`